### PR TITLE
Added capability to configure a double click event on rows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,8 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "table",
-      "version": "1.0.0",
+      "name": "dynamic-data-grid",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.6"

--- a/src/DynamicDataGrid.xml
+++ b/src/DynamicDataGrid.xml
@@ -176,6 +176,10 @@
                     <caption>On click action</caption>
                     <description />
                 </property>
+                <property key="onDoubleClickRow" type="action" required="false" dataSource="dataSourceRow">
+                    <caption>On double click action</caption>
+                    <description />
+                </property>
             </propertyGroup>
             <propertyGroup caption="Column header">
                 <property key="onClickColumnHeader" type="action" required="false" dataSource="dataSourceColumn">

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -6,7 +6,7 @@ interface CellProps {
     children: ReactNode;
     className?: string;
     key: string;
-    onClick?: () => void;
+    onClick?: (event: React.MouseEvent) => void;
     rowIndex: number;
     renderAs: RenderAsEnum;
 }
@@ -32,7 +32,7 @@ export function Cell(props: CellProps): ReactElement {
                                   props.onClick
                               ) {
                                   e.preventDefault();
-                                  props.onClick();
+                                  props.onClick;
                               }
                           }
                         : undefined
@@ -53,7 +53,7 @@ export function Cell(props: CellProps): ReactElement {
                     ? e => {
                           if ((e.key === "Enter" || e.key === " ") && e.target === e.currentTarget && props.onClick) {
                               e.preventDefault();
-                              props.onClick();
+                              props.onClick;
                           }
                       }
                     : undefined

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -6,7 +6,7 @@ interface CellProps {
     children: ReactNode;
     className?: string;
     key: string;
-    onClick?: (event: React.MouseEvent) => void;
+    onClick?: (event?: React.MouseEvent) => void;
     rowIndex: number;
     renderAs: RenderAsEnum;
 }
@@ -32,7 +32,7 @@ export function Cell(props: CellProps): ReactElement {
                                   props.onClick
                               ) {
                                   e.preventDefault();
-                                  props.onClick;
+                                  props.onClick();
                               }
                           }
                         : undefined
@@ -53,7 +53,7 @@ export function Cell(props: CellProps): ReactElement {
                     ? e => {
                           if ((e.key === "Enter" || e.key === " ") && e.target === e.currentTarget && props.onClick) {
                               e.preventDefault();
-                              props.onClick;
+                              props.onClick();
                           }
                       }
                     : undefined

--- a/src/components/Cells.tsx
+++ b/src/components/Cells.tsx
@@ -69,11 +69,15 @@ Please make sure your cell sort order and row sort order are matching, and cell 
             }
 
             const onClick = (e: React.MouseEvent) =>
-                cell && onClickCell ? onClickCell?.get(cell).execute()
-                : (onClickRow && e.detail === 1) ? onClickRow?.get(row).execute()
-                : (onDoubleClickRow && e.detail === 2) ? onDoubleClickRow?.get(row).execute()
-                : onClickColumn ? onClickColumn?.get(column).execute()
-                : undefined;
+                cell && onClickCell
+                    ? onClickCell?.get(cell).execute()
+                    : onClickRow && e.detail === 1
+                    ? onClickRow?.get(row).execute()
+                    : onDoubleClickRow && e.detail === 2
+                    ? onDoubleClickRow?.get(row).execute()
+                    : onClickColumn
+                    ? onClickColumn?.get(column).execute()
+                    : undefined;
 
             const cellClassColumn = columnClass?.get(column).value ?? undefined;
             const cellClassValue = (cell && cellClass?.get(cell).value) ?? undefined;

--- a/src/components/Cells.tsx
+++ b/src/components/Cells.tsx
@@ -54,7 +54,7 @@ export function Cells(props: CellsProps): ReactElement {
     const { dataSourceCell, referenceRow, referenceColumn, dataSourceColumn, renderAs, pageCell } = props;
     const { showRowAs, columnClass, cellClass } = props;
     const { row, rowIndex, loading } = props;
-    const { onClickRow, onClickCell, onClickColumn, onClickRowHeader } = props;
+    const { onClickRow, onDoubleClickRow, onClickCell, onClickColumn, onClickRowHeader } = props;
     // potential optimize with hash table?
     const cells =
         dataSourceColumn.items?.map(column => {
@@ -68,14 +68,13 @@ Please make sure your cell sort order and row sort order are matching, and cell 
                 );
             }
 
-            const onClick =
-                cell && onClickCell
-                    ? (): void => onClickCell?.get(cell).execute()
-                    : onClickRow
-                    ? (): void => onClickRow?.get(row).execute()
-                    : onClickColumn
-                    ? (): void => onClickColumn?.get(column).execute()
-                    : undefined;
+            const onClick = (e: React.MouseEvent) =>
+                cell && onClickCell ? onClickCell?.get(cell).execute()
+                : (onClickRow && e.detail === 1) ? onClickRow?.get(row).execute()
+                : (onDoubleClickRow && e.detail === 2) ? onDoubleClickRow?.get(row).execute()
+                : onClickColumn ? onClickColumn?.get(column).execute()
+                : undefined;
+
             const cellClassColumn = columnClass?.get(column).value ?? undefined;
             const cellClassValue = (cell && cellClass?.get(cell).value) ?? undefined;
             return (

--- a/typings/DynamicDataGridProps.d.ts
+++ b/typings/DynamicDataGridProps.d.ts
@@ -53,6 +53,7 @@ export interface DynamicDataGridContainerProps {
     columnClass?: ListExpressionValue<string>;
     onClickRowHeader?: ListActionValue;
     onClickRow?: ListActionValue;
+    onDoubleClickRow?: ListActionValue;
     onClickColumnHeader?: ListActionValue;
     onClickColumn?: ListActionValue;
     onClickCell?: ListActionValue;
@@ -99,6 +100,7 @@ export interface DynamicDataGridPreviewProps {
     columnClass: string;
     onClickRowHeader: {} | null;
     onClickRow: {} | null;
+    onDoubleClickRow: {} | null;
     onClickColumnHeader: {} | null;
     onClickColumn: {} | null;
     onClickCell: {} | null;


### PR DESCRIPTION
Can also implement this for cells and columns, but for our current use case rows only require double click.
It uses the React.MouseEvent to detect the number of clicks and based on that either trigger the normal onClick action or a new onDoubleClickAction.